### PR TITLE
Adds a configurable IP whitelist protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ cp config.yml.dist config.yml
 - **json**: The location of your *satis.json* file. Default: ```satis.json```.
 - **webroot**: The location of your satis webroot, where packages.json is going to be dumped. Default: ```web/```.
 - **user**: The location of your *bin/satis* file. This parameter is optional and default to ```null```.
+- **authorized_ips**: The IP address list allowed to access the page. This parameter is optional and default to the current GitHub hook servers (```[204.232.175.64/27, 192.30.252.0/22]```).
 
 Make your ```webhook.php``` file accessible, for example:
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "require": {
         "symfony/process": "~2.2.0",
-        "symfony/yaml": "~2.2.0"
+        "symfony/yaml": "~2.2.0",
+        "symfony/http-foundation": "~2.2.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,19 +1,73 @@
 {
-    "hash": "ee42fbb166b65897d0c7eb820d062397",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "3626654274e70ae492694c9b5d18ee8f",
     "packages": [
         {
+            "name": "symfony/http-foundation",
+            "version": "v2.2.5",
+            "target-dir": "Symfony/Component/HttpFoundation",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/HttpFoundation.git",
+                "reference": "v2.2.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/v2.2.5",
+                "reference": "v2.2.5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "classmap": [
+                    "Symfony/Component/HttpFoundation/Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony HttpFoundation Component",
+            "homepage": "http://symfony.com",
+            "time": "2013-08-07 14:00:53"
+        },
+        {
             "name": "symfony/process",
-            "version": "v2.2.0",
+            "version": "v2.2.5",
             "target-dir": "Symfony/Component/Process",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",
-                "reference": "v2.2.0-RC3"
+                "reference": "v2.2.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/v2.2.0-RC3",
-                "reference": "v2.2.0-RC3",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/v2.2.5",
+                "reference": "v2.2.5",
                 "shasum": ""
             },
             "require": {
@@ -46,21 +100,21 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "http://symfony.com",
-            "time": "2013-02-18 21:28:10"
+            "time": "2013-07-21 12:15:26"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.2.0",
+            "version": "v2.2.5",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "v2.2.0-RC3"
+                "reference": "v2.2.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/v2.2.0-RC3",
-                "reference": "v2.2.0-RC3",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/v2.2.5",
+                "reference": "v2.2.5",
                 "shasum": ""
             },
             "require": {
@@ -93,7 +147,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2013-01-27 16:49:19"
+            "time": "2013-07-11 09:28:01"
         }
     ],
     "packages-dev": [

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -2,3 +2,4 @@ bin: bin/satis   # Where your satis bin is located
 json: satis.json # Where your satis.json is located
 webroot: web     # Where you want to dump index.html and packages.json
 user: ~          # Run script as another user (sudo -u user -i bin/satis build ...)
+authorized_ips: [204.232.175.64/27, 192.30.252.0/22] # Authorized IP address (defaults are GitHub Hook servers). Use ~ if you want to allow all IPs


### PR DESCRIPTION
I made a quick modification to the script to allow only a list of IPs to access the page.

The user can configure the list in the config file, or disable the protection. The defaults IPs are the GitHub hook servers IPs.

I also update the composer.lock file since the vendor packages URL were outdated (Sensiolabs change their GitHub corporation name few month ago).
