### PR TITLE
Update repositories on GitHub and Gitlab separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 composer.phar
 vendor/
 config.yml
+satis/
+include/
+packages.json
+satis.json
+index.html

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cp config.yml.dist config.yml
 - **json**: The location of your *satis.json* file. Default: ```satis.json```.
 - **webroot**: The location of your satis webroot, where packages.json is going to be dumped. Default: ```web/```.
 - **user**: The location of your *bin/satis* file. This parameter is optional and default to ```null```.
-
+- **secret**: The secret of your webhook
 Make your ```webhook.php``` file accessible, for example:
 
 ```

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -2,3 +2,4 @@ bin: bin/satis   # Where your satis bin is located
 json: satis.json # Where your satis.json is located
 webroot: web     # Where you want to dump index.html and packages.json
 user: ~          # Run script as another user (sudo -u user -i bin/satis build ...)
+secret: mysecret # Your secret configured in your webhook call


### PR DESCRIPTION
Added functionality where Satis only updates only repositories defined in the JSON data from the web hook call. Webhook can also still be called without JSON-data, which results in the update of all repositories defined in satis.json. Also add secret check when calling the webhook from GitHub or GitLab.
Secret is added to the config.yml file.